### PR TITLE
Fix cider-nrepl versioning conflict

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -9,7 +9,7 @@
   :source-paths ["src/clj"]
 
   :plugins [[lein-cljsbuild "1.0.6"]
-            [lein-figwheel "0.3.3"]]
+            [lein-figwheel "0.3.3" :exclusions [cider/cider-nrepl]]]
 
   :clean-targets ^{:protect false} ["resources/public/js/compiled" "target"]
 


### PR DESCRIPTION
https://github.com/bhauman/lein-figwheel/issues/149
Think is a simple fix for whose who also use cider. There're quite a few people puzzled by this error (https://github.com/clojure-emacs/cider/issues/961) so I think this could save quite a lot of time for them. I'm also curious if you'd want occasional PRs just to update outdated deps.