### PR TITLE
Set output-dir for tests in project.clj

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -74,8 +74,9 @@
     {{#test?}}
     {:id           "test"
      :source-paths ["src/cljs" "test/cljs"]
-     :compiler     {:output-to     "resources/public/js/compiled/test.js"
-                    :main          {{name}}.runner
+     :compiler     {:main          {{name}}.runner
+                    :output-to     "resources/public/js/compiled/test.js"
+                    :output-dir    "resources/public/js/compiled/test/out"
                     :optimizations :none}}{{/test?}}
     ]}
 {{#handler?}}


### PR DESCRIPTION
Fixes figwheel error about unique output-dir, fixes #33