### PR TITLE
Add comment on how to run production min build in project.cls

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -62,7 +62,9 @@
                     :output-dir           "resources/public/js/compiled/out"
                     :asset-path           "js/compiled/out"
                     :source-map-timestamp true}}
-
+    ;; This next build is an compressed minified build for
+    ;; production. You can build this with:
+    ;; lein cljsbuild once min
     {:id           "min"
      :source-paths ["src/cljs"]{{#handler?}}
      :jar true{{/handler?}}


### PR DESCRIPTION
Even though it was mentioned in README file, developers usually look in the source code. For example, I was trying to run `lein figwheel min` first, so I think this comment can be useful.