### PR TITLE
Update re-frame-template for 0.9.0

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -2,7 +2,7 @@
   :dependencies [[org.clojure/clojure "1.8.0"]
                  [org.clojure/clojurescript "1.9.229"]
                  [reagent "0.6.0"]
-                 [re-frame "0.8.0"]{{#re-frisk?}}
+                 [re-frame "0.9.0"]{{#re-frisk?}}
                  [re-frisk "0.3.0"]{{/re-frisk?}}{{#re-com?}}
                  [org.clojure/core.async "0.2.391"]
                  [re-com "0.8.3"]{{/re-com?}}{{#routes?}}

--- a/src/leiningen/new/re_frame/src/cljs/core.cljs
+++ b/src/leiningen/new/re_frame/src/cljs/core.cljs
@@ -16,6 +16,7 @@
     (println "dev mode")))
 
 (defn mount-root []
+  (re-frame/clear-subscription-cache!)
   (reagent/render [views/main-panel]
                   (.getElementById js/document "app")))
 


### PR DESCRIPTION
- Clear subscription cache when reloading with Figwheel

This isn't ready yet, as re-frame 0.9.0 isn't out, but can be merged once 0.9.0 is out.