### PR TITLE
Set empty default build profile

### DIFF
--- a/src/leiningen/new/re_frame/README.md
+++ b/src/leiningen/new/re_frame/README.md
@@ -65,7 +65,7 @@ lein dev
 {{^aliases?}}
 ```
 lein clean
-lein figwheel dev
+lein with-profile dev figwheel dev
 ```
 {{/aliases?}}
 

--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -52,7 +52,9 @@
 {{/aliases?}}
 
   :profiles
-  {:dev
+  {:default []
+
+   :dev
    {:dependencies [[binaryage/devtools "0.9.4"]{{#cider?}}
                    [figwheel-sidecar "0.5.13"]
                    [com.cemerick/piggieback "0.2.2"]{{/cider?}}{{#re-frisk?}}


### PR DESCRIPTION
From some debugging on a project I've been doing today, it seem that the `dev` profile is used for all builds, since it's the only profile present and thus becomes the default. 

No harm done, in most cases, as the extra couple of libraries are stripped by the dead code removal, but confusing in the situation when an additional profile is explicitly needed. Minor change here sets an explicit (and empty) default profile, and updates the associated lein command. 