### PR TITLE
Add lein deps to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,12 @@ When using +aliases css also gets automatically built when running `lein build` 
 
 ## Run application:
 
+Retreive dependencies:
+```
+lein deps
+```
+
+Then run:
 ```
 lein clean
 lein figwheel dev


### PR DESCRIPTION
I've stumbled on the same issue as described in https://github.com/Day8/re-frame-template/issues/60.
My suggestion would be to explicitly add `lein deps` to the readme.