### PR TITLE
Use `cider.piggieback`

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -38,7 +38,7 @@
   :less {:source-paths ["less"]
          :target-path  "resources/public/css"}
 {{/less?}}{{#cider?}}
-  :repl-options {:nrepl-middleware [cemerick.piggieback/wrap-cljs-repl]}
+  :repl-options {:nrepl-middleware [cider.piggieback/wrap-cljs-repl]}
 {{/cider?}}
 {{#aliases?}}
 
@@ -59,7 +59,7 @@
                    [day8.re-frame/re-frame-10x "0.3.3"]
                    [day8.re-frame/tracing "0.5.1"]{{/10x?}}{{#cider?}}
                    [figwheel-sidecar "0.5.16"]
-                   [cider/piggieback "0.2.3"]{{/cider?}}{{#re-frisk?}}
+                   [cider/piggieback "0.3.5"]{{/cider?}}{{#re-frisk?}}
                    [re-frisk "0.5.3"]{{/re-frisk?}}]
 
     :plugins      [[lein-figwheel "0.5.16"]{{#test?}}


### PR DESCRIPTION
The current config does not seem to work with newer versions of cider, as something changed with `cemerick.piggieback/wrap-cljs-repl`.