### PR TITLE
Use .dir-locals.el with CIDER (#49)

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,18 +58,13 @@ lein new re-frame <project-name> +garden +re-com +routes +test +less +10x
 >  Note: to assist debugging, you'll want to include either `+10x` or `+re-frisk` 
 
 
-## Start Cider from Emacs (if using +cider):
+## Start CIDER from Emacs (if using +cider):
 
-Put this in your Emacs config file:
+The latest versions of CIDER support various clojurescript REPLs, including
+Figwheel. When using the `+cider` option, a `.dir-locals.el` file is added
+to the root directory which sets `cider-default-cljs-repl` to `figwheel`.
 
-```
-(setq cider-cljs-lein-repl
-	"(do (require 'figwheel-sidecar.repl-api)
-         (figwheel-sidecar.repl-api/start-figwheel!)
-         (figwheel-sidecar.repl-api/cljs-repl))")
-```
-
-Navigate to a clojurescript file and start a figwheel REPL with `cider-jack-in-clojurescript` or (`C-c M-J`)
+Navigate to a clojurescript file and start a Figwheel REPL with `cider-jack-in-cljs` or (`C-c M-J`).
 
 
 ## Compile css (if using +garden or +less):

--- a/src/leiningen/new/options/cider.clj
+++ b/src/leiningen/new/options/cider.clj
@@ -1,0 +1,7 @@
+(ns leiningen.new.options.cider
+  (:require [leiningen.new.options.helpers :as helpers]))
+
+(def option "+cider")
+
+(defn files [data]
+  [[".dir-locals.el" (helpers/render ".dir-locals.el" data)]])

--- a/src/leiningen/new/re_frame.clj
+++ b/src/leiningen/new/re_frame.clj
@@ -8,6 +8,7 @@
    [leiningen.new.options.re-com :as re-com]
    [leiningen.new.options.routes :as routes]
    [leiningen.new.options.test :as test]
+   [leiningen.new.options.cider :as cider]
    [leiningen.new.options.views :as views]
    [leiningen.new.options.helpers :as helpers]
    [leiningen.new.options.gadfly :as gadfly] ;; <-- intentionally undocumented
@@ -37,6 +38,7 @@
 
      ;; development
      (when (helpers/option? test/option options) (test/files data))
+     (when (helpers/option? cider/option options) (cider/files data))
 
      ;; full-stack
      (when (helpers/option? handler/option options) (handler/files data))
@@ -63,7 +65,7 @@
    :10x?      (helpers/option? "+10x" options)
 
    ;; devlopment
-   :cider?   (helpers/invoke-option "+cider" options)
+   :cider?   (helpers/invoke-option cider/option options)
    :test?    (helpers/invoke-option test/option options)
    :aliases? (helpers/option? "+aliases" options)
 
@@ -98,7 +100,7 @@
     "+10x"
 
     ;; development
-    "+cider"
+    cider/option
     test/option
     "+aliases"
 

--- a/src/leiningen/new/re_frame/.dir-locals.el
+++ b/src/leiningen/new/re_frame/.dir-locals.el
@@ -1,0 +1,2 @@
+((nil
+  (cider-default-cljs-repl . figwheel)))

--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -67,7 +67,7 @@
     :plugins      [[lein-figwheel "0.5.16"]{{#test?}}
                    [lein-doo "0.1.8"]{{/test?}}{{#aliases?}}
                    [lein-pdo "0.1.1"]{{/aliases?}}]}
-   :prod { {{#10x?}}:dependencies [[day8.re-frame/tracing-stubs "0.5.1"]]{{/10x?}}}}
+    :prod { {{#10x?}}:dependencies [[day8.re-frame/tracing-stubs "0.5.1"]]{{/10x?}}}}
 
   :cljsbuild
   {:builds


### PR DESCRIPTION
Here is my take on #49 considering the recent changes to CIDER.

In a nutshell, the option `cider-cljs-lein-repl` has been deprecated; instead, there is `cider-default-cljs-repl` which does the magic (actually, runs the same Figwheel commands) when set to `figwheel` (here is a link to the [CIDER docs](
http://www.cider.mx/en/latest/clojurescript/#starting-a-clojurescript-repl)).

I've also found this [in the docs](
http://www.cider.mx/en/latest/clojurescript/#piggieback):

> If `cider-inject-dependencies-at-jack-in` is enabled (which is the default) then piggieback will be automatically added and configured for your project when doing `cider-jack-in-cljs`.

but did not do anything about it, being scared that removing the dependency might break something (I've seen a commit message about putting it back).