### PR TITLE
simplifiy shadow-cljs config

### DIFF
--- a/src/leiningen/new/re_frame/resources/public/index.html
+++ b/src/leiningen/new/re_frame/resources/public/index.html
@@ -13,6 +13,5 @@
   <body>
     <div id="app"></div>
     <script src="js/compiled/app.js"></script>
-    <script>{{sanitized}}.core.init();</script>
   </body>
 </html>

--- a/src/leiningen/new/re_frame/shadow-cljs.edn
+++ b/src/leiningen/new/re_frame/shadow-cljs.edn
@@ -5,25 +5,16 @@
  :builds {:app {:target          :browser
                 :output-dir      "resources/public/js/compiled"
                 :asset-path      "/js/compiled"
-                :dev             {:modules          {:app {:entries [devtools.preload{{#10x?}}
-                                                                     day8.re-frame-10x.preload{{/10x?}}{{#re-frisk?}}
-                                                                     re-frisk.preload{{/re-frisk?}}
-                                                                     {{name}}.core]}}{{#10x?}}
-                                  :compiler-options {:closure-defines {re-frame.trace.trace-enabled?        true
+                :modules         {:app {:init-fn {{name}}.core/init
+                                        :preloads [devtools.preload{{#10x?}}
+                                                   day8.re-frame-10x.preload{{/10x?}}{{#re-frisk?}}
+                                                   re-frisk.preload{{/re-frisk?}}]}}{{#10x?}}
+                :dev             {:compiler-options {:closure-defines {re-frame.trace.trace-enabled?        true
                                                                        day8.re-frame.tracing.trace-enabled? true}}{{/10x?}}}
-                :release         {:modules          {:app {:entries [{{name}}.core]}}
-                                  :compiler-options {:optimizations :advanced
-                                                     :pretty-print  false
-                                                     :closure-defines {goog.DEBUG                           false{{#10x?}}
-                                                                       re-frame.trace.trace-enabled?        false
-                                                                       day8.re-frame.tracing.trace-enabled? false{{/10x?}}}}}
                 :devtools        {:http-root    "resources/public"
                                   :http-port    8280{{#handler?}}
                                   :http-handler {{name}}.handler/dev-handler{{/handler?}}
-                                  :preloads     [devtools.preload{{#10x?}}
-                                                 day8.re-frame-10x.preload{{/10x?}}{{#re-frisk?}}
-                                                 re-frisk.preload{{/re-frisk?}}]
-                                  :after-load   {{name}}.core/mount-root}}{{#test?}}
+                                  }}{{#test?}}
 
           :browser-test
           {:target :browser-test

--- a/src/leiningen/new/re_frame/src/cljs/core.cljs
+++ b/src/leiningen/new/re_frame/src/cljs/core.cljs
@@ -13,15 +13,14 @@
 
 (defn dev-setup []
   (when config/debug?
-    (enable-console-print!)
     (println "dev mode")))
 
-(defn mount-root []
+(defn ^:dev/after-load mount-root []
   (re-frame/clear-subscription-cache!)
   (reagent/render [views/main-panel]
                   (.getElementById js/document "app")))
 
-(defn ^:export init []{{#routes?}}
+(defn init []{{#routes?}}
   (routes/app-routes){{/routes?}}
   (re-frame/dispatch-sync [::events/initialize-db]){{#re-pressed?}}
   (re-frame/dispatch-sync [::rp/add-keyboard-event-listener "keydown"]){{/re-pressed?}}{{#breaking-point?}}


### PR DESCRIPTION
The generated `shadow-cljs.edn` file has a bunch of extra repeated code that isn't required and makes the config more complex than it needs to be.