### PR TITLE
remove "empty" generated core.clj

### DIFF
--- a/src/leiningen/new/options/base.clj
+++ b/src/leiningen/new/options/base.clj
@@ -9,7 +9,6 @@
    ["package.json" (helpers/render "package.json" data)]
    ["karma.conf.js" (helpers/render "karma.conf.js" data)]
    ["resources/public/index.html" (helpers/render "resources/public/index.html" data)]
-   ["src/clj/{{sanitized}}/core.clj" (helpers/render "src/clj/core.clj" data)]
    ["src/cljs/{{sanitized}}/core.cljs" (helpers/render "src/cljs/core.cljs" data)]
    ["src/cljs/{{sanitized}}/config.cljs" (helpers/render "src/cljs/config.cljs" data)]
    ["src/cljs/{{sanitized}}/db.cljs" (helpers/render "src/cljs/db.cljs" data)]

--- a/src/leiningen/new/re_frame/src/clj/core.clj
+++ b/src/leiningen/new/re_frame/src/clj/core.clj
@@ -1,1 +1,0 @@
-(ns {{ns-name}}.core)


### PR DESCRIPTION
It is unused and using the same NS for CLJ/CLJS should be limited to macro namespaces which this isn't.

It also confuses [new users](https://stackoverflow.com/questions/57791249/why-are-there-clj-and-cljs-folders-in-my-lein-re-frame-template).