### PR TITLE
fix: completely remove runner.cljs from test option

### DIFF
--- a/src/leiningen/new/options/test.clj
+++ b/src/leiningen/new/options/test.clj
@@ -4,5 +4,4 @@
 (def option "+test")
 
 (defn files [data]
-  [["test/cljs/{{sanitized}}/runner.cljs" (helpers/render "test/cljs/runner.cljs" data)]
-   ["test/cljs/{{sanitized}}/core_test.cljs" (helpers/render "test/cljs/core_test.cljs" data)]])
+  [["test/cljs/{{sanitized}}/core_test.cljs" (helpers/render "test/cljs/core_test.cljs" data)]])


### PR DESCRIPTION
Fixes #104

My apologies for introducing this bug in #101 .

Tested PR as follows:

```sh
lein install
lein new re-frame noooooooo
cd noooooooo
lein deps && npm install
lein karma
```

Karma ran `fake-test` properly.