### PR TITLE
fix: add lein, node, shadow-cljs items to .gitignore

### DIFF
--- a/src/leiningen/new/re_frame/gitignore
+++ b/src/leiningen/new/re_frame/gitignore
@@ -1,8 +1,8 @@
-/*.log
-/target
+/out/
+/resources/public/js/compiled/
+/target/
 /*-init.clj
-/resources/public/js/compiled
-out
+/*.log
 
 # Leiningen
 /.lein-*

--- a/src/leiningen/new/re_frame/gitignore
+++ b/src/leiningen/new/re_frame/gitignore
@@ -3,3 +3,13 @@
 /*-init.clj
 /resources/public/js/compiled
 out
+
+# Leiningen
+/.lein-*
+/.nrepl-port
+
+# Node.js dependencies
+/node_modules/
+
+# shadow-cljs cache, port files
+/.shadow-cljs/


### PR DESCRIPTION
Fixes #108

Referenced [leiningen/resources/leiningen/new/template/gitignore](https://github.com/technomancy/leiningen/blob/stable/resources/leiningen/new/template/gitignore) for Leiningen `.gitignore` items.

Slashes added for clarity and specificity to allow users to name their files and directories without issue.