### PR TITLE
fix: add Garden/Less CSS gen to build prep-tasks

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -79,5 +79,7 @@
              :main         {{ns-name}}.server
              :aot          [{{ns-name}}.server]
              :uberjar-name "{{name}}.jar"
-             :prep-tasks   ["compile" ["prod"]{{{prep-garden}}}{{{prep-less}}}]}{{/handler?}}
-   })
+             :prep-tasks   ["compile" ["prod"]{{{prep-garden}}}{{{prep-less}}}]}{{/handler?}}}
+
+  :prep-tasks [{{#garden?}}["garden" "once"]{{/garden?}}{{#less?}}
+               ["less" "once"]{{/less?}}])


### PR DESCRIPTION
Fixes #110

From [`lein-garden README`](https://github.com/noprompt/lein-garden/blob/master/README.md#chapter-3):
> Now you might want stylesheets to always compile whenever starting your program with leiningen. Add this to your `project.clj`
> ```clj
> :prep-tasks [["garden" "once"]]
> ```

Tested as follows:

1. Create and prep projects for each CSS option:
```sh
PROJDIR=`pwd`
DIFFDIR=`mktemp -d`

# Create a project for each CSS option, move to DIFFDIR
lein new re-frame aa                           && mv aa $DIFFDIR/
lein new re-frame aa-garden +garden            && mv aa-garden $DIFFDIR/
lein new re-frame aa-garden-less +garden +less && mv aa-garden-less $DIFFDIR/
lein new re-frame aa-less +less                && mv aa-less $DIFFDIR/

# Download each project's dependencies
for D in $DIFFDIR/*; do cd $D; lein deps && npm install; cd $PROJDIR; done
```
2. Manually test each project with `lein dev`, editing Garden/Less source files, generating, and verifying the browser hot reloads the changes
3. Clean up
```sh
rm -rf $DIFFDIR
```