### PR TITLE
docs: add setup linting in editor link to README

### DIFF
--- a/src/leiningen/new/re_frame/README.md
+++ b/src/leiningen/new/re_frame/README.md
@@ -111,7 +111,9 @@ dependency management)
 9. Setup [lint cache](https://github.com/borkdude/clj-kondo#project-setup):
     ```sh
     clj-kondo --lint "$(lein classpath)"
-    ```{{/kondo?}}
+    ```
+10. Setup
+[linting in your editor](https://github.com/borkdude/clj-kondo/blob/master/doc/editor-integration.md){{/kondo?}}
 
 ### Browser Setup
 


### PR DESCRIPTION
From [comment on PR 116](https://github.com/day8/re-frame-template/pull/116#issuecomment-570060288):

> may be worth adding a link directly for other editors like Cursive and VS Code to https://github.com/borkdude/clj-kondo/blob/master/doc/editor-integration.md

Tested by building new projects, uploading to github, visually inspecting as well as diffing.