### PR TITLE
fix: add standard meta, title, noscript to index.html

### DIFF
--- a/src/leiningen/new/re_frame/resources/public/index.html
+++ b/src/leiningen/new/re_frame/resources/public/index.html
@@ -1,16 +1,22 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
   <head>
-    <meta charset='utf-8'>{{#re-com?}}
+    <meta charset='utf-8'>
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">{{#re-com?}}
     <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="vendor/css/material-design-iconic-font.min.css">
     <link rel="stylesheet" href="vendor/css/re-com.css">
     <link href="http://fonts.googleapis.com/css?family=Roboto:300,400,500,700,400italic" rel="stylesheet" type="text/css">
-    <link href="http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300" rel="stylesheet" type="text/css">{{/re-com?}}
-    {{#garden?}}<link href="css/screen.css" rel="stylesheet" type="text/css">{{/garden?}}
-    {{#less?}}<link href="css/site.css" rel="stylesheet" type="text/css">{{/less?}}
+    <link href="http://fonts.googleapis.com/css?family=Roboto+Condensed:400,300" rel="stylesheet" type="text/css">{{/re-com?}}{{#garden?}}
+    <link href="css/screen.css" rel="stylesheet" type="text/css">{{/garden?}}{{#less?}}
+    <link href="css/site.css" rel="stylesheet" type="text/css">{{/less?}}
+    <title>{{name}}</title>
   </head>
   <body>
+    <noscript>
+      {{name}} is a JavaScript app. Please enable JavaScript to continue.
+    </noscript>
     <div id="app"></div>
     <script src="js/compiled/app.js"></script>
   </body>

--- a/src/leiningen/new/re_frame/resources/public/index.html
+++ b/src/leiningen/new/re_frame/resources/public/index.html
@@ -2,8 +2,7 @@
 <html lang="en">
   <head>
     <meta charset='utf-8'>
-    <meta http-equiv="X-UA-Compatible" content="IE=edge">
-    <meta name="viewport" content="width=device-width,initial-scale=1.0">{{#re-com?}}
+    <meta name="viewport" content="width=device-width,initial-scale=1">{{#re-com?}}
     <link rel="stylesheet" href="http://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/3.3.5/css/bootstrap.min.css">
     <link rel="stylesheet" href="vendor/css/material-design-iconic-font.min.css">
     <link rel="stylesheet" href="vendor/css/re-com.css">


### PR DESCRIPTION
Fixes #118

In addition to adding the items mentioned in #118...
* Capitalized `!DOCTYPE`
  - Although it's not case-sensitive in html5, most examples have it capitalized, as required in SGML and XML
  - Lower case may lead some devs to believe that it's incorrect, wasting time on upper-casing it and committing
* Moved opening template tags to the end of the previous line
  - Prevents stray newlines in new projects

Tested with new projects with all affected options, using `lein dev` and manually checking in browser.