### PR TITLE
Update package.json with create-react-class with 15.6.3

### DIFF
--- a/src/leiningen/new/re_frame/package.json
+++ b/src/leiningen/new/re_frame/package.json
@@ -1,6 +1,7 @@
 {
   "devDependencies": {
     "shadow-cljs": "2.8.83"{{#test?}},
+    "create-react-class": "15.6.3",
     "karma": "4.4.1",
     "karma-chrome-launcher": "3.1.0",
     "karma-cljs-test": "0.1.0",


### PR DESCRIPTION
It fixes -https://github.com/day8/re-frame-template/issues/123
Problem Desc-
After creating a new project
lein new re-frame "project_name" +test +10x and lein dev
Was getting following error
<Error>
shadow-cljs - watching build :app
[:app] Configuring build.
[:app] Compiling ...
[:app] Build failure:
The required namespace "create-react-class" is not available, it was required by "day8/re_frame_10x/inlined_deps/reagent/v0v8v1/reagent/impl/component.cljs".
The namespace was provided via :foreign-libs which is not supported.
Please refer to https://shadow-cljs.github.io/docs/UsersGuide.html#cljsjs for more information.
You may just need to run:
  npm install create-react-class
</Error>