### PR TITLE
Update secretary to v1.2.4

### DIFF
--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -9,7 +9,7 @@
                  [re-frame "0.12.0"]{{#10x?}}
                  [day8.re-frame/tracing "0.5.5"]{{/10x?}}{{#re-com?}}
                  [re-com "2.8.0"]{{/re-com?}}{{#routes?}}
-                 [secretary "1.2.3"]{{/routes?}}{{#garden?}}
+                 [clj-commons/secretary "1.2.4"]{{/routes?}}{{#garden?}}
                  [garden "1.3.10"]
                  [ns-tracker "0.4.0"]{{/garden?}}{{#handler?}}
                  [compojure "1.6.1"]


### PR DESCRIPTION
Fixes broken route parameter support on new ClojureScript version as also discussed here: https://github.com/day8/re-frame/issues/530