### PR TITLE
Fix uberjar target and Heroku instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,18 @@ Create uberjar
 
 ```
 lein clean
-lein with-profile prod uberjar
+lein uberjar
 ```
 
 Create app on heroku
 
 ```
+git init .
+git add -A
+git commit -m "Initial commit"
 heroku create
+heroku buildpacks:add heroku/nodejs
+heroku buildpacks:add heroku/clojure
 ```
 
 Then deploy the application

--- a/src/leiningen/new/re_frame/README.md
+++ b/src/leiningen/new/re_frame/README.md
@@ -345,12 +345,25 @@ If `port` is not set, the server will run on port 3000 by default.
 
 ### Deploying to Heroku
 
-1. [Create a Heroku app](https://devcenter.heroku.com/articles/creating-apps):
+1. Heroku deploys happen from a git repository:
+    ```sh
+    git init .
+    git add -A
+    git commit -m "Initial commit"
+    ```
+
+2. [Create a Heroku app](https://devcenter.heroku.com/articles/creating-apps):
     ```sh
     heroku create
     ```
 
-2. [Deploy the app code](https://devcenter.heroku.com/articles/git#deploying-code):
+3. [Add the relevant buildpacks](https://devcenter.heroku.com/articles/using-node-js-with-clojure-and-clojurescript-applications)
+    ```sh
+    heroku buildpacks:add heroku/nodejs
+    heroku buildpacks:add heroku/clojure
+    ```
+
+4. [Deploy the app code](https://devcenter.heroku.com/articles/git#deploying-code):
 
     ```sh
     git push heroku master

--- a/src/leiningen/new/re_frame/project.clj
+++ b/src/leiningen/new/re_frame/project.clj
@@ -124,7 +124,7 @@
              :main         {{ns-name}}.server
              :aot          [{{ns-name}}.server]
              :uberjar-name "{{name}}.jar"
-             :prep-tasks   ["compile" ["prod"]{{{prep-garden}}}{{{prep-less}}}]}{{/handler?}}}
+             :prep-tasks   ["compile" ["release"]{{{prep-garden}}}{{{prep-less}}}]}{{/handler?}}}
 
   :prep-tasks [{{#garden?}}["garden" "once"]{{/garden?}}{{#less?}}
                ["less" "once"]{{/less?}}])


### PR DESCRIPTION
The `uberjar` target gives the following warning:

```
"DEPRECATED: Please use lein release instead."
```

This pull request modifies it to use the new `production` target instead. It also fixes the Heroku instructions, which seem to have succumbed to bit-rot at some point.