### PR TITLE
Fix karma-test and browser-test configs

### DIFF
--- a/src/leiningen/new/re_frame/shadow-cljs.edn
+++ b/src/leiningen/new/re_frame/shadow-cljs.edn
@@ -2,7 +2,7 @@
 
  {{#cider?}}:jvm-opts ["-Xmx1G"]{{/cider?}}
 
- :source-paths ["src"]
+ :source-paths ["src" "test"]
 
  :dependencies
  [[reagent "1.0.0"]

--- a/src/leiningen/new/re_frame/shadow-cljs.edn
+++ b/src/leiningen/new/re_frame/shadow-cljs.edn
@@ -52,13 +52,13 @@
    {:build-options
     {:ns-aliases
      {day8.re-frame.tracing day8.re-frame.tracing-stubs}}}{{/10x?}}{{#test?}}
+  {{/test?}}}
   :browser-test
   {:target    :browser-test
    :ns-regexp "-test$"
    :runner-ns shadow.test.browser
    :test-dir  "target/browser-test"}
-
   :karma-test
   {:target    :karma
    :ns-regexp "-test$"
-   :output-to "target/karma-test.js"}{{/test?}}}}}
+   :output-to "target/karma-test.js"}}}


### PR DESCRIPTION
When I create a new re-frame project with the template (`+test`) and run `npm run ci` I get the following error: `{:build-id :karma-test, :known-builds #{:app :npm}}` I think the place of these (karma-test and browser-test) builds misplaced (they shouldn't inside of :app).