### PR TITLE
Fix clj-kondo configuration for garden and spade

### DIFF
--- a/src/leiningen/new/re_frame/clj-kondo/config.edn
+++ b/src/leiningen/new/re_frame/clj-kondo/config.edn
@@ -1,10 +1,13 @@
 {:lint-as {{=<% %>=}}{<%#10x?%><%={{ }}=%>day8.re-frame.tracing/defn-traced clojure.core/defn
            day8.re-frame.tracing/fn-traced clojure.core/fn{{/10x?}}{{#garden?}}
-           garden.def/defcssfn clojure.core/def
+           garden.def/defcssfn clojure.core/defn
            garden.def/defkeyframes clojure.core/def
            garden.def/defrule clojure.core/def
            garden.def/defstyles clojure.core/def
-           garden.def/defstylesheet clojure.core/def{{/garden?}}}
+           garden.def/defstylesheet clojure.core/def
+           garden.units/defunit clojure.core/def
+           spade.core/defglobal clojure.core/def
+           spade.core/defclass clojure.core/def{{/garden?}}
  :linters {:unresolved-symbol {:exclude [goog.DEBUG]}
            :unused-namespace {:exclude [cljs.repl]}
            :unused-referred-var {:exclude {cljs.repl [Error->map


### PR DESCRIPTION
Currently, in a project generated by:
```
clojure -Tclj-new create :template re-frame :name sample/playground :output sample-playground :args '[+kondo +garden +routes "+10x"]'
```
clj-kondo in shows lots of errors in `styles.cljs` due to invalid clj-kondo configuration.

This PR fixes all the errors, although some more tweaking is needed to also tackle the `Unresolved var: deg` warning too.

EDIT:
Above mentioned warning fixed too