### PR TITLE
Add clj-kondo hooks configs and lsp cache to gitignore

### DIFF
--- a/src/leiningen/new/re_frame/gitignore
+++ b/src/leiningen/new/re_frame/gitignore
@@ -14,5 +14,11 @@
 # shadow-cljs cache, port files
 /.shadow-cljs/{{#kondo?}}
 
-# clj-kondo cache
-/.clj-kondo/.cache{{/kondo?}}
+# clj-kondo cache and configs from libs
+/.clj-kondo/*
+
+# clj-kondo config
+!/.clj-kondo/config.edn
+
+# clojure-lsp cache
+/.lsp/.cache{{/kondo?}}


### PR DESCRIPTION
Currently using `clj-kondo` through `clojure-lsp` (I believe a pretty common case), populates the `.clj-kondo/` directory with configuration from `hooks configs exported by libs on classpath during startup lint` as per the default `:copy-kondo-configs?` value of `clojure-lsp` (https://clojure-lsp.io/settings/)

This PR extends the generated gitignore to ignore all the generated (copied) clj-kondo configuration from the dependencies, along with the clojure-lsp cache folder.