### PR TITLE
fix: parenthesis imbalance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 #### Changed
 
+- Upgrade re-frame-10x to 1.7.0
 - Upgrade shadow-cljs to 2.20.5
 
 ## 2.4.8

--- a/README.md
+++ b/README.md
@@ -149,10 +149,10 @@ I'll assume Chrome for the purposes of further explanation:
 
 To use `re-frame-10x` for debugging your app:
   1. click on the application, minimal through it is, to give it "input focus" (you want to be sure that any key presses are going to your new app)
-  2. press `Ctrl-H` and you should see the `re-frame-10x` panel appear on the right side of the window
+  2. press `Ctrl-Shift-X` and you should see the `re-frame-10x` panel appear on the right side of the window
 
 Sometimes achieving Step 1 on a really simple app - one without widgets - can be fiddly,
-because the browser itself hogs "input focus" and grabs all the keystrokes (like `Ctrl-H`) which don't
+because the browser itself hogs "input focus" and grabs all the keystrokes (like `Ctrl-Shift-X`) which don't
 then make it through to your app. You may need to be determined and creative with Step 1.
 I have every confidence in you.
 

--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ I have every confidence in you.
 
 ## Hot Reloading Is Now Go
 
-If you now edit files, shadow-clj will automatically
+If you now edit files, shadow-cljs will automatically
 recompile your changes and "hot load" them into your running app, without your app needing
 to be re-started. The resulting fast, iterative workflow tends to make you very productive, and
 is cherished by those lucky enough to experience it.

--- a/src/leiningen/new/re_frame/clj-kondo/config.edn
+++ b/src/leiningen/new/re_frame/clj-kondo/config.edn
@@ -7,7 +7,7 @@
            garden.def/defstylesheet clojure.core/def
            garden.units/defunit clojure.core/def
            spade.core/defglobal clojure.core/def
-           spade.core/defclass clojure.core/def{{/garden?}}
+           spade.core/defclass clojure.core/def{{/garden?}}}
  :linters {:unresolved-symbol {:exclude [goog.DEBUG]}
            :unused-namespace {:exclude [cljs.repl]}
            :unused-referred-var {:exclude {cljs.repl [Error->map

--- a/src/leiningen/new/re_frame/shadow-cljs.edn
+++ b/src/leiningen/new/re_frame/shadow-cljs.edn
@@ -17,7 +17,7 @@
   [re-pressed "0.3.2"]{{/re-pressed?}}{{#breaking-point?}}
   [breaking-point "0.1.2"]{{/breaking-point?}}
   [binaryage/devtools "1.0.6"]{{#10x?}}
-  [day8.re-frame/re-frame-10x "1.5.0"]{{/10x?}}{{#re-frisk?}}
+  [day8.re-frame/re-frame-10x "1.7.0"]{{/10x?}}{{#re-frisk?}}
   [re-frisk "1.6.0"]{{/re-frisk?}}{{#cider?}}
   [cider/cider-nrepl "0.28.4"]{{/cider?}}{{#git-inject?}}
   [day8/shadow-git-inject "0.0.5"]{{/git-inject?}}]{{#git-inject?}}


### PR DESCRIPTION
the +kondo options creates a clj-kondo config.edn file with imbalanced parenthesis

config.edn before this fix:  
```edn
{:lint-as {
 :linters {:unresolved-symbol {:exclude [goog.DEBUG]}
           :unused-namespace {:exclude [cljs.repl]}
           :unused-referred-var {:exclude {cljs.repl [Error->map
                                                      apropos
                                                      dir
                                                      doc
                                                      error->str
                                                      ex-str
                                                      ex-triage
                                                      find-doc
                                                      print-doc
                                                      pst
                                                      source]}}}}
```

config.edn after this fix:
```edn
{:lint-as {}
 :linters {:unresolved-symbol {:exclude [goog.DEBUG]}
           :unused-namespace {:exclude [cljs.repl]}
           :unused-referred-var {:exclude {cljs.repl [Error->map
                                                      apropos
                                                      dir
                                                      doc
                                                      error->str
                                                      ex-str
                                                      ex-triage
                                                      find-doc
                                                      print-doc
                                                      pst
                                                      source]}}}}
```