### PR TITLE
Modernise re-frame-template

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -1,0 +1,5 @@
+issue_prefix: rft
+issue-prefix: rft
+dolt.auto-start: false
+gc.endpoint_origin: inherited_city
+gc.endpoint_status: verified

--- a/.beads/metadata.json
+++ b/.beads/metadata.json
@@ -1,0 +1,7 @@
+{
+  "database": "dolt",
+  "backend": "dolt",
+  "dolt_mode": "embedded",
+  "dolt_database": "rft",
+  "project_id": "gc-local-4ddcd009d44212b57f84f74ba4b18d17"
+}

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,26 @@
+{
+  "hooks": {
+    "PreCompact": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ],
+    "SessionStart": [
+      {
+        "hooks": [
+          {
+            "command": "bd prime",
+            "type": "command"
+          }
+        ],
+        "matcher": ""
+      }
+    ]
+  }
+}

--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -15,19 +15,19 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # All of the Git history is required for day8/lein-git-inject to determine the version string.
           fetch-depth: 0
       - name: Maven cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /root/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj', '.github/workflows/**') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('project.clj') }}-${{ hashFiles('**/package.json') }}
@@ -36,7 +36,7 @@ jobs:
       - name: Test Templates
         run: ./create-templates.sh
       - name: Slack notification
-        uses: homoluctus/slatify@v2.0.1
+        uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1
         if: failure() || cancelled()
         with:
           type: ${{ job.status }}
@@ -56,12 +56,12 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # All of the Git history is required for day8/lein-git-inject to determine the version string.
           fetch-depth: 0
       - name: Maven cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /root/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj', '.github/workflows/**') }}
@@ -80,7 +80,7 @@ jobs:
       # we always want the latest release to show in the right hand column of the project
       # page regardless of if it is a stable release.
       - name: Create GitHub Release
-        uses: actions/create-release@v1
+        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
@@ -91,7 +91,7 @@ jobs:
           draft: false
           prerelease: false
       - name: Slack notification
-        uses: homoluctus/slatify@v2.0.1
+        uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1
         if: always()
         with:
           type: ${{ job.status }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -19,19 +19,19 @@ jobs:
         username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@93cb6efe18208431cddfb8368fd83d5badbf9bfd # v5
         with:
           # All of the Git history is required for day8/lein-git-inject to determine the version string.
           fetch-depth: 0
       - name: Maven cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /root/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj', '.github/workflows/**') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: npm cache
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('project.clj') }}-${{ hashFiles('**/package.json') }}
@@ -40,7 +40,7 @@ jobs:
       - name: Test Templates
         run: ./create-templates.sh
       - name: Slack notification
-        uses: homoluctus/slatify@v2.0.1
+        uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1
         if: failure() || cancelled()
         with:
           type: ${{ job.status }}

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,13 @@ pom.xml.asc
 temp
 .lsp/sqlite*.db
 .calva/output-window/*.calva-repl
+
+# Gas City
+.beads/*
+!.beads/config.yaml
+!.beads/metadata.json
+
+# Beads / Dolt files (added by bd init)
+.dolt/
+*.db
+.beads-credential-key

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,84 @@
+# Agent Instructions
+
+This project uses **bd** (beads) for issue tracking. Run `bd prime` for full workflow context.
+
+## Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work atomically
+bd close <id>         # Complete work
+bd dolt push          # Push beads data to remote
+```
+
+## Non-Interactive Shell Commands
+
+**ALWAYS use non-interactive flags** with file operations to avoid hanging on confirmation prompts.
+
+Shell commands like `cp`, `mv`, and `rm` may be aliased to include `-i` (interactive) mode on some systems, causing the agent to hang indefinitely waiting for y/n input.
+
+**Use these forms instead:**
+```bash
+# Force overwrite without prompting
+cp -f source dest           # NOT: cp source dest
+mv -f source dest           # NOT: mv source dest
+rm -f file                  # NOT: rm file
+
+# For recursive operations
+rm -rf directory            # NOT: rm -r directory
+cp -rf source dest          # NOT: cp -r source dest
+```
+
+**Other commands that may prompt:**
+- `scp` - use `-o BatchMode=yes` for non-interactive
+- `ssh` - use `-o BatchMode=yes` to fail instead of prompting
+- `apt-get` - use `-y` flag
+- `brew` - use `HOMEBREW_NO_AUTO_UPDATE=1` env var
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 2.4.14
+
+#### Changed
+
+- Upgrade re-frame-10x to 1.11.0 (new flows panel, UUID display settings, app-db edit fixes)
+- Upgrade shadow-cljs to 2.28.23 (note: shadow-cljs 3.x is available but requires Java 21)
+
 ## 2.4.13
 
 #### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,69 @@
+# Project Instructions for AI Agents
+
+This file provides instructions and context for AI coding agents working on this project.
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   bd dolt push
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->
+
+
+## Build & Test
+
+_Add your build and test commands here_
+
+```bash
+# Example:
+# npm install
+# npm test
+```
+
+## Architecture Overview
+
+_Add a brief overview of your project architecture_
+
+## Conventions & Patterns
+
+_Add your project-specific conventions here_

--- a/resources/leiningen/new/re_frame/package.json
+++ b/resources/leiningen/new/re_frame/package.json
@@ -12,7 +12,7 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"shadow-cljs": "2.26.2"{{#test?}},
+		"shadow-cljs": "2.28.23"{{#test?}},
         "karma": "6.4.0",
         "karma-chrome-launcher": "3.1.1",
         "karma-cljs-test": "0.1.0",

--- a/resources/leiningen/new/re_frame/shadow-cljs.edn
+++ b/resources/leiningen/new/re_frame/shadow-cljs.edn
@@ -17,7 +17,7 @@
   [re-pressed "0.3.2"]{{/re-pressed?}}{{#breaking-point?}}
   [breaking-point "0.1.2"]{{/breaking-point?}}
   [binaryage/devtools "1.0.6"]{{#10x?}}
-  [day8.re-frame/re-frame-10x "1.9.3"]{{/10x?}}{{#re-frisk?}}
+  [day8.re-frame/re-frame-10x "1.11.0"]{{/10x?}}{{#re-frisk?}}
   [re-frisk "1.6.0"]{{/re-frisk?}}{{#cider?}}
   [cider/cider-nrepl "0.44.0"]{{/cider?}}{{#git-inject?}}
   [day8/shadow-git-inject "0.0.5"]{{/git-inject?}}]{{#git-inject?}}


### PR DESCRIPTION
## Summary

Bundles the recent local work in `re-frame-template` for review.

## Commit Range

- Base: `origin/master`
- Commits: `3`

## Recent Commits

- 8494b6c ci: pin every action ref to a SHA so the workflows actually run
- 334d5fa rft-rfg: bump re-frame-10x to 1.11.0 and shadow-cljs to 2.28.23
- 549881d bd init: initialize beads issue tracking

## Validation

- Not run as part of PR creation.
