### PR TITLE
Modernise CI follow-ups: shadow-cljs 3.x, GitHub Actions refresh

### DIFF
--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -36,15 +36,16 @@ jobs:
       - name: Test Templates
         run: ./create-templates.sh
       - name: Slack notification
-        uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         if: failure() || cancelled()
         with:
-          type: ${{ job.status }}
-          job_name: re-frame-template Tests
-          channel: '#oss-robots'
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          commit: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*re-frame-template Tests*: ${{ job.status }}\nCommit: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+            }
+
   release:
     name: Release
     needs: test
@@ -80,23 +81,22 @@ jobs:
       # we always want the latest release to show in the right hand column of the project
       # page regardless of if it is a stable release.
       - name: Create GitHub Release
-        uses: actions/create-release@0cb9c9b65d5d1901c1f53e5e66eaf4afd303e70e # v1
+        uses: softprops/action-gh-release@b4309332981a82ec1c5618f44dd2e27cc8bfbfda # v3.0.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: ${{ github.ref }}
-          release_name: ${{ github.ref }}
+          name: ${{ github.ref_name }}
           body: |
             [Changelog](https://github.com/day8/re-frame-template/blob/master/CHANGELOG.md)
           draft: false
           prerelease: false
       - name: Slack notification
-        uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         if: always()
         with:
-          type: ${{ job.status }}
-          job_name: re-frame-template Deployment
-          channel: '#oss-robots'
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          commit: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*re-frame-template Deployment*: ${{ job.status }}\nCommit: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+            }

--- a/.github/workflows/continuous-deployment-workflow.yml
+++ b/.github/workflows/continuous-deployment-workflow.yml
@@ -20,14 +20,14 @@ jobs:
           # All of the Git history is required for day8/lein-git-inject to determine the version string.
           fetch-depth: 0
       - name: Maven cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /root/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj', '.github/workflows/**') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: npm cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('project.clj') }}-${{ hashFiles('**/package.json') }}
@@ -62,7 +62,7 @@ jobs:
           # All of the Git history is required for day8/lein-git-inject to determine the version string.
           fetch-depth: 0
       - name: Maven cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /root/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj', '.github/workflows/**') }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -24,14 +24,14 @@ jobs:
           # All of the Git history is required for day8/lein-git-inject to determine the version string.
           fetch-depth: 0
       - name: Maven cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: /root/.m2/repository
           key: ${{ runner.os }}-maven-${{ hashFiles('project.clj', '.github/workflows/**') }}
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: npm cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.npm
           key: ${{ runner.os }}-npm-${{ hashFiles('project.clj') }}-${{ hashFiles('**/package.json') }}

--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -40,12 +40,12 @@ jobs:
       - name: Test Templates
         run: ./create-templates.sh
       - name: Slack notification
-        uses: homoluctus/slatify@61c6b12d2ae226db04062ff9b43d9679e2d53236 # v2.0.1
+        uses: slackapi/slack-github-action@03ea5433c137af7c0495bc0cad1af10403fc800c # v3.0.2
         if: failure() || cancelled()
         with:
-          type: ${{ job.status }}
-          job_name: re-frame-template Tests
-          channel: '#oss-robots'
-          url: ${{ secrets.SLACK_WEBHOOK }}
-          commit: true
-          token: ${{ secrets.GITHUB_TOKEN }}
+          webhook: ${{ secrets.SLACK_WEBHOOK }}
+          webhook-type: incoming-webhook
+          payload: |
+            {
+              "text": "*re-frame-template Tests*: ${{ job.status }}\nCommit: <https://github.com/${{ github.repository }}/commit/${{ github.sha }}|${{ github.sha }}>"
+            }

--- a/resources/leiningen/new/re_frame/package.json
+++ b/resources/leiningen/new/re_frame/package.json
@@ -12,6 +12,6 @@
 		"react-dom": "17.0.2"
 	},
 	"devDependencies": {
-		"shadow-cljs": "2.28.23"
+		"shadow-cljs": "3.4.6"
 	}
 }


### PR DESCRIPTION
## Summary

Closes the modernisation arc started on master in commits `6426eb0` (rft-2aq), `7988154` (rft-ebc), and `62b170a` (rft-kul). This branch picks up the three follow-ups that were filed during that work:

- **rft-0p0** *(partial)* — bump generated-app's `shadow-cljs` npm devDep `2.28.23 → 3.4.6`. Crosses the 2.x → 3.x major-version line. The bead stays open as a tracker for the four upstream releases that hadn't landed at filing time (re-frame 1.4.6, re-frame-10x next, re-com 2.29.3, day8.re-frame/tracing next) — see bead notes.
- **rft-5a2** — replace deprecated `actions/create-release@v1` with `softprops/action-gh-release@v3.0.0` (SHA-pinned).
- **rft-5ac** — replace unmaintained `homoluctus/slatify` (last release 2020) with `slackapi/slack-github-action@v3.0.2` (SHA-pinned). Configured in `webhook` mode with `webhook-type: incoming-webhook` so the existing `SLACK_WEBHOOK` secret keeps working unchanged — no secret rotation needed. Three call sites updated (CI failure, CD failure, CD always-fire).

## Context — what already landed on master

The conservative arc landed direct-to-master before this branch was cut:

| Commit | Bead | What |
| --- | --- | --- |
| `6426eb0` | rft-2aq | Conservative dep bumps in `shadow-cljs.edn` (reagent 1.2.0, re-frame 1.4.5, re-com 2.29.2, devtools 1.0.7, re-frisk 1.7.1, cider-nrepl 0.59.0, shadow-git-inject 0.0.10). Held React 17 + shadow-cljs 2.x. |
| `7988154` | rft-ebc | Dropped karma; switched to shadow-cljs `:node-test`. Generated app's CI no longer needs Chrome — `ubuntu-latest` + `setup-node` + `setup-java`. |
| `62b170a` | rft-kul | Bumped template's own CI/CD `chrome-56:2 → chrome-latest:2` (still needed for `create-templates.sh`'s headless smoke). |

## Test plan

- [ ] CI on this branch (`./create-templates.sh`) — exercises every options permutation, `npm install + npm run release` per generated app, headless-Chrome page load
- [ ] One generated `+test` permutation should run `npm run ci` cleanly under shadow-cljs 3.x's `:node-test`
- [ ] On a future tag push, verify `softprops/action-gh-release` creates the GitHub Release with the correct title (`${{ github.ref_name }}`) and CHANGELOG link
- [ ] Manually trigger or wait for a CI failure — confirm `slackapi/slack-github-action` posts to `#oss-robots` via the existing `SLACK_WEBHOOK` secret

🤖 Generated with [Claude Code](https://claude.com/claude-code)